### PR TITLE
Bump PROTOCOL_VERSION

### DIFF
--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -1,7 +1,7 @@
 var log = require('../util/log');
 
 var MAX_RECEIVE_BUFFER = 10000000;
-var PROTOCOL_VERSION = 70103;
+var PROTOCOL_VERSION = 70206;
 
 var Put = require('bufferput');
 var Buffers = require('buffers');
@@ -585,6 +585,11 @@ Connection.prototype.parseMessage = function(command, payload) {
     case 'fbvote':
     // sync
     case 'ssc':
+    // sendheaders
+    case 'sendheaders':
+    // gobject
+    case 'govobj':
+    case 'govobjvote':
       break;
 
     default:


### PR DESCRIPTION
Bump PROTOCOL_VERSION to 70206
Ignore new Commands as not implemented: 'sendheaders','govobj','govobjvote'